### PR TITLE
Remove promise plugin dependency (deprecated plugin)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -25,8 +25,6 @@
     <engine name="cordova" version=">=3.0.0"/>
   </engines>
 
-  <dependency id="es6-promise-plugin" version="^4.1.0" />
-
   <js-module src="www/SocialSharing.js" name="SocialSharing">
     <clobbers target="window.plugins.socialsharing" />
   </js-module>


### PR DESCRIPTION
Would be nice to avoid the warning in capacitor about a missing plugin.
Every modern browser has promises now, I don't think this plugin is needed any more.
More over, I've tested this plugin without installing the promise and it works as expected.
Would be great if you could merge this and create a new version...